### PR TITLE
Allow explicit password setting for new collaborators

### DIFF
--- a/nextjs_space/app/dashboard/collaborators/page.tsx
+++ b/nextjs_space/app/dashboard/collaborators/page.tsx
@@ -30,6 +30,7 @@ export default function CollaboratorsPage() {
   const [sharedWithMe, setSharedWithMe] = useState<SharedWithMeEntry[]>([])
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [collaboratorPassword, setCollaboratorPassword] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
@@ -59,7 +60,7 @@ export default function CollaboratorsPage() {
       const res = await fetch('/api/collaborators', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({ email, password, collaboratorPassword: collaboratorPassword || undefined }),
       })
 
       const data = await res.json()
@@ -70,12 +71,13 @@ export default function CollaboratorsPage() {
       }
 
       if (data.newUserCreated) {
-        setSuccess(`Er is een nieuw account aangemaakt voor ${email}. Deze persoon kan inloggen via "Wachtwoord vergeten" om een eigen wachtwoord in te stellen, en heeft nu toegang tot je administratie.`)
+        setSuccess(`Er is een nieuw account aangemaakt voor ${email}. Deze persoon kan nu inloggen met het opgegeven wachtwoord en heeft toegang tot je administratie.`)
       } else {
         setSuccess(`${email} heeft nu toegang tot je administratie`)
       }
       setEmail('')
       setPassword('')
+      setCollaboratorPassword('')
       fetchCollaborators()
     } catch {
       setError('Er is iets misgegaan')
@@ -116,7 +118,7 @@ export default function CollaboratorsPage() {
         </CardHeader>
         <CardContent>
           <form onSubmit={handleAdd} className="space-y-4">
-            <div className="grid gap-4 sm:grid-cols-2">
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
               <div className="space-y-2">
                 <Label htmlFor="email">Emailadres van collaborator</Label>
                 <Input
@@ -127,6 +129,17 @@ export default function CollaboratorsPage() {
                   onChange={e => setEmail(e.target.value)}
                   required
                 />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="collaboratorPassword">Wachtwoord voor collaborator</Label>
+                <Input
+                  id="collaboratorPassword"
+                  type="password"
+                  placeholder="Wachtwoord voor nieuw account"
+                  value={collaboratorPassword}
+                  onChange={e => setCollaboratorPassword(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">Alleen nodig als de persoon nog geen account heeft</p>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="password">Jouw wachtwoord (bevestiging)</Label>


### PR DESCRIPTION
## Summary
Changed the collaborator invitation flow to require an explicit password when creating a new account, instead of auto-generating a temporary password that users would need to reset via "Forgot Password".

## Key Changes
- **API Route (`/api/collaborators`)**: 
  - Removed unused `crypto` import
  - Added `collaboratorPassword` parameter to POST request
  - Changed from auto-generating random passwords to using the provided password
  - Added validation to require `collaboratorPassword` when creating new accounts

- **UI (`/dashboard/collaborators/page.tsx`)**:
  - Added new "Wachtwoord voor collaborator" (Collaborator Password) input field
  - Updated form grid layout from 2 columns to 3 columns on large screens to accommodate the new field
  - Updated success message to reflect that users can now login directly with the provided password
  - Added helper text indicating the password field is only needed for new accounts

## Implementation Details
- The `collaboratorPassword` field is optional in the UI but required by the API when creating a new user account
- If a collaborator already has an account, the password field is ignored
- The password is sent as `undefined` when empty, allowing the API to distinguish between "not provided" and "empty string"
- User-facing messages are in Dutch (nl) to match the application's language

https://claude.ai/code/session_01ChVaw3C1tuVc5UAf2cPose